### PR TITLE
Fix openssl setup script

### DIFF
--- a/SetupOpenssl.sh
+++ b/SetupOpenssl.sh
@@ -230,9 +230,6 @@ if [ ! -z "$VERBOSE" ] && [ "$VERBOSE" != "0" ]; then
   echo "ANDROID_DEV: $ANDROID_DEV"
 fi
 
-./config shared no-ssl3 no-comp no-hw no-engine --openssldir=/usr/local/ssl/android-14/
+./config shared no-ssl3 no-comp no-hw no-engine
 make depend
 make all
-find . -name libcrypto.a
-readelf -h ./libcrypto.a | grep -i 'class\|machine' | head -2
-make install CC=$ANDROID_TOOLCHAIN/arm-linux-androideabi-gcc RANLIB=$ANDROID_TOOLCHAIN/arm-linux-androideabi-ranlib


### PR DESCRIPTION
The setup script unnecessarily tried to install openssl to
/usr/local/ssl. This will fail on most machines and is not necessary, as
the subsequent build steps will just fetch the library from its source
directory.

This problem was brought up on the f-droid gitlab: https://gitlab.com/fdroid/rfp/issues/199
It's probably a blocker for #12 .