### PR TITLE
Fix compilation of JSON library with Android NDK

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -9,6 +9,10 @@ cmake_minimum_required(VERSION 3.4.1)
 # You can define multiple libraries, and CMake builds it for you.
 # Gradle automatically packages shared libraries with your APK.
 
+add_compile_options(
+    -UANDROID
+)
+
 add_library( # Sets the name of the library.
      passman-lib
 


### PR DESCRIPTION
The JSON library used in this project contains a workaround for an old
version of the Android NDK. On a current NDK, this leads to a duplicate
declaration of wcsncasecmp.

Compile the native libraries with -UANDROID to disable the troublesome
workaround.

I'm using the ndk-bundle that is installed by the Android SDK manager. I run the 
build using the gradle wrapper and it uses the following compiler:
dk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++

The compile error this fixes looks as follows:

    In file included from /home/hong/git/passman-android/app/src/main/cpplibs/SimpleJSON/src/JSON.cpp:25:
    ../../../../src/main/cpplibs/SimpleJSON/src/JSON.h:50:20: error: static declaration of 'wcsncasecmp' follows non-static declaration
          static inline int wcsncasecmp(const wchar_t *s1, const wchar_t *s2, size_t n)
                            ^
    .../Android/Sdk/ndk-bundle/sysroot/usr/include/wchar.h:121:19: note: previous declaration is here
    int               wcsncasecmp(const wchar_t *, const wchar_t *, size_t);
                      ^