### PR TITLE
Add build instructions for gradle properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,15 @@ The passwords will be provided by [passman](https://github.com/nextcloud/passman
 1. Copy `Openssl.conf.sample` to `Openssl.conf`
 1. Edit the NDK path in Openssl.conf to match your local NDK path
 1. Run `SetupOpenssl.sh`
-1. Use android studio to build or otherwise build with gradle.
+1. If you want to compile either an alpha or release version, create a keystore either
+with Android Studio or `keytool` and add at least a key for the alpha build:
+    ```
+    keytool -genkey -v -keystore keystore.jks -alias beta
+    ```
+1. Create a gradle.properties file based on gradle.properties.example and fill in the
+appropriate values for your keystore. If you only build debug builds you can leave
+the default values.
+1. Use Android Studio to build or otherwise build with gradle.
 
 ## Testing server
 If you want access to a passman testing server, poke us on irc (freenode/#passman-dev)


### PR DESCRIPTION
As mentioned on #28:
The build instructions were missing a hint about the gradle properties
file and the keystore needed for alpha and release builds.