### PR TITLE
Fix debug build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,9 @@ android {
             resValue "string", "app_name", "@string/app_name_release"
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        debug {
+            resValue "string", "app_name", "@string/app_name_release"
+        }
         debubug {
             debuggable true
             jniDebuggable true


### PR DESCRIPTION
The application name was not defined for the debug build type, see #28.