### PR TITLE
Don't display deleted credentials

### DIFF
--- a/app/src/main/java/es/wolfi/passman/API/Vault.java
+++ b/app/src/main/java/es/wolfi/passman/API/Vault.java
@@ -182,7 +182,7 @@ public class Vault extends Core {
                 Credential c = Credential.fromJSON(j.getJSONObject(i), v);
                 if(c.getDeleteTime() == 0) {
                     v.credentials.add(c);
-                    v.credential_guid.put(c.getGuid(), i);
+                    v.credential_guid.put(c.getGuid(), v.credentials.size() - 1);
                 }
             }
             v.challenge_password = v.credentials.get(0).password;

--- a/app/src/main/java/es/wolfi/passman/API/Vault.java
+++ b/app/src/main/java/es/wolfi/passman/API/Vault.java
@@ -180,10 +180,11 @@ public class Vault extends Core {
 
             for (int i = 0; i < j.length(); i++) {
                 Credential c = Credential.fromJSON(j.getJSONObject(i), v);
-                v.credentials.add(c);
-                v.credential_guid.put(c.getGuid(), i);
+                if(c.getDeleteTime() == 0) {
+                    v.credentials.add(c);
+                    v.credential_guid.put(c.getGuid(), i);
+                }
             }
-
             v.challenge_password = v.credentials.get(0).password;
         }
         else {


### PR DESCRIPTION
Check the `hidden` property of a credential before adding it to the list of credentials of a vault.

This should fix #23 