### PR TITLE
fix KeyStore initialization

### DIFF
--- a/app/src/main/java/es/wolfi/utils/KeyStoreUtils.java
+++ b/app/src/main/java/es/wolfi/utils/KeyStoreUtils.java
@@ -103,8 +103,8 @@ public class KeyStoreUtils {
                                         .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
                                         .setRandomizedEncryptionRequired(false)
                                         .build());
-                        SecretKey key = keyGenerator.generateKey();
-                        keyStore.setKeyEntry(KEY_ALIAS, key, null, null);
+
+                        keyGenerator.generateKey();
 
                         SecureRandom random = SecureRandom.getInstance(RANDOM_ALGORITHM);
                         byte[] encryptionKeyBytes = new byte[4096];


### PR DESCRIPTION
the removed line `keyStore.setKeyEntry(KEY_ALIAS, key, null, null);` overwrote the key that was generated and automatically saved by generateKey(). that caused a null pointer exception since Android API 31