### PR TITLE
Remove build id from the embedded libpassman-lib

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -4,6 +4,10 @@
 
 cmake_minimum_required(VERSION 3.4.1)
 
+# Avoid generating build IDs to improve the reproducibility of builds.
+# https://izzyondroid.org/docs/reproducibleBuilds/DebugFailedRBs/#build-ids
+add_link_options(-Wl,--build-id=none)
+
 # Creates and names a library, sets it as either STATIC
 # or SHARED, and provides the relative paths to its source code.
 # You can define multiple libraries, and CMake builds it for you.


### PR DESCRIPTION
closes #188 

How to test:
1. Build the app in Android Studio before applying the patch
2. Run `readelf -n app/build/intermediates/cxx/Debug/481q4g5c/obj/arm64-v8a/libpassman-lib.so` and replace `481q4g5c` with the actual one
    - This shows something like "Build ID: 69411c5f969bec759ed05bc3f915e0da88505d0c"
3. Apply the patch and build the app again in Android Studio
4. Run the command from above again (replace `481q4g5c` with the actual recent one) and the output won't contain the ".note.gnu.build-id" block at all