### PR TITLE
Add app/vault security features

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-feature
         android:name="android.hardware.camera"
@@ -16,6 +17,7 @@
     </queries>
 
     <application
+        android:name=".PassmanApp"
         android:allowBackup="false"
         android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
@@ -47,13 +49,15 @@
             android:theme="@android:style/Theme.NoDisplay" />
         <activity
             android:name=".activities.AutofillInteractionActivity"
-            android:theme="@style/AppTheme.NoActionBar"/>
+            android:theme="@style/AppTheme.NoActionBar"
+            tools:targetApi="26" />
 
         <service
             android:name=".autofill.CredentialAutofillService"
             android:exported="false"
             android:label="Passman Credential Autofill Service"
-            android:permission="android.permission.BIND_AUTOFILL_SERVICE">
+            android:permission="android.permission.BIND_AUTOFILL_SERVICE"
+            tools:targetApi="26">
             <meta-data
                 android:name="android.autofill"
                 android:resource="@xml/autofill_service" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <queries>
         <package android:name="com.nextcloud.client" />

--- a/app/src/main/java/es/wolfi/app/passman/PassmanApp.java
+++ b/app/src/main/java/es/wolfi/app/passman/PassmanApp.java
@@ -1,0 +1,55 @@
+package es.wolfi.app.passman;
+
+import android.app.Activity;
+import android.app.Application;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class PassmanApp extends Application {
+    private Activity currentActivity;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        registerActivityLifecycleCallbacks(new ActivityLifecycleCallbacks() {
+            @Override
+            public void onActivityCreated(@NonNull Activity activity, @Nullable Bundle savedInstanceState) {}
+
+            @Override
+            public void onActivityStarted(@NonNull Activity activity) {
+                currentActivity = activity;
+            }
+
+            @Override
+            public void onActivityResumed(@NonNull Activity activity) {
+                currentActivity = activity;
+            }
+
+            @Override
+            public void onActivityPaused(@NonNull Activity activity) {
+                if (currentActivity == activity) {
+                    currentActivity = null;
+                }
+            }
+
+            @Override
+            public void onActivityStopped(@NonNull Activity activity) {}
+
+            @Override
+            public void onActivitySaveInstanceState(@NonNull Activity activity, @NonNull Bundle outState) {}
+
+            @Override
+            public void onActivityDestroyed(@NonNull Activity activity) {
+                if (currentActivity == activity) {
+                    currentActivity = null;
+                }
+            }
+        });
+    }
+
+    public Activity getCurrentActivity() {
+        return currentActivity;
+    }
+}

--- a/app/src/main/java/es/wolfi/app/passman/SettingValues.java
+++ b/app/src/main/java/es/wolfi/app/passman/SettingValues.java
@@ -44,7 +44,8 @@ public enum SettingValues {
     CREDENTIAL_LABEL_SORT("credential_label_sort"),
     CASE_INSENSITIVE_CREDENTIAL_LABEL_SORT("case_insensitive_credential_label_sort"),
     RESTORE_CUSTOM_CREDENTIAL_SORT_ORDER("restore_custom_credential_sort_order"),
-    VAULT_AUTO_LOCK_DELAY("vault_auto_lock_delay");
+    VAULT_AUTO_LOCK_DELAY("vault_auto_lock_delay"),
+    ENABLE_SCREENSHOT_PROTECTION("enable_screenshot_protection");
 
     private final String name;
 

--- a/app/src/main/java/es/wolfi/app/passman/SettingValues.java
+++ b/app/src/main/java/es/wolfi/app/passman/SettingValues.java
@@ -43,7 +43,8 @@ public enum SettingValues {
     KEY_STORE_ENCRYPTION_KEY("key_store_encryption_key"),
     CREDENTIAL_LABEL_SORT("credential_label_sort"),
     CASE_INSENSITIVE_CREDENTIAL_LABEL_SORT("case_insensitive_credential_label_sort"),
-    RESTORE_CUSTOM_CREDENTIAL_SORT_ORDER("restore_custom_credential_sort_order");
+    RESTORE_CUSTOM_CREDENTIAL_SORT_ORDER("restore_custom_credential_sort_order"),
+    VAULT_AUTO_LOCK_DELAY("vault_auto_lock_delay");
 
     private final String name;
 

--- a/app/src/main/java/es/wolfi/app/passman/VaultLockManager.java
+++ b/app/src/main/java/es/wolfi/app/passman/VaultLockManager.java
@@ -3,7 +3,6 @@ package es.wolfi.app.passman;
 import android.app.Activity;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
-import android.content.Context;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
@@ -26,6 +25,7 @@ public class VaultLockManager {
     private Runnable lockRunnable;
     private Runnable countdownRunnable;
     private int timeoutMinutes = 0;
+    private long lastInteractionTime = 0;
     private final PassmanApp passmanApp;
 
     private VaultLockManager(PassmanApp passmanApp) {
@@ -58,6 +58,8 @@ public class VaultLockManager {
     }
 
     public void resetTimer() {
+        lastInteractionTime = System.currentTimeMillis();
+        
         handler.removeCallbacks(lockRunnable);
         handler.removeCallbacks(countdownRunnable);
         
@@ -77,6 +79,34 @@ public class VaultLockManager {
         } else {
             countdownRunnable = () -> startCountdown(3);
             handler.postDelayed(countdownRunnable, countdownStartMillis);
+        }
+    }
+
+    public void checkLockOnResume() {
+        if (timeoutMinutes <= 0) return;
+
+        long currentTime = System.currentTimeMillis();
+        long elapsedMillis = currentTime - lastInteractionTime;
+        long timeoutMillis = (long) timeoutMinutes * 60 * 1000;
+
+        if (elapsedMillis >= timeoutMillis) {
+            Log.d(TAG, "Lock timeout exceeded during background/pause, locking now");
+            lockActiveVault();
+        } else {
+            // Recalculate remaining time and reschedule
+            resetTimer();
+            // Adjust the timer to account for elapsed time
+            handler.removeCallbacks(lockRunnable);
+            handler.removeCallbacks(countdownRunnable);
+            
+            long remainingMillis = timeoutMillis - elapsedMillis;
+            if (remainingMillis <= 3000) {
+                lockRunnable = this::lockActiveVault;
+                handler.postDelayed(lockRunnable, remainingMillis);
+            } else {
+                countdownRunnable = () -> startCountdown(3);
+                handler.postDelayed(countdownRunnable, remainingMillis - 3000);
+            }
         }
     }
 
@@ -106,13 +136,13 @@ public class VaultLockManager {
         }
     }
 
-    private void lockActiveVault() {
+    public void lockActiveVault() {
         hideOverlayOnCurrentActivity();
         
         SingleTon ton = SingleTon.getTon();
         Vault vault = (Vault) ton.getExtra(SettingValues.ACTIVE_VAULT.toString());
         if (vault != null && vault.is_unlocked()) {
-            Log.d(TAG, "Inactivity timeout reached, locking vault");
+            Log.d(TAG, "Locking active vault");
             vault.lock();
             ton.addExtra(SettingValues.ACTIVE_VAULT.toString(), vault);
             ton.addExtra(vault.guid, vault);

--- a/app/src/main/java/es/wolfi/app/passman/VaultLockManager.java
+++ b/app/src/main/java/es/wolfi/app/passman/VaultLockManager.java
@@ -1,33 +1,55 @@
 package es.wolfi.app.passman;
 
 import android.app.Activity;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+
+import es.wolfi.app.passman.activities.BaseActivity;
 import es.wolfi.app.passman.activities.PasswordListActivity;
 import es.wolfi.passman.API.Vault;
 
 public class VaultLockManager {
     private static final String TAG = "VaultLockManager";
+    private static final String CHANNEL_ID = "vault_security";
+    private static final int NOTIFICATION_ID = 1001;
+    
     private static VaultLockManager instance;
     private final Handler handler = new Handler(Looper.getMainLooper());
     private Runnable lockRunnable;
+    private Runnable countdownRunnable;
     private int timeoutMinutes = 0;
     private final PassmanApp passmanApp;
 
     private VaultLockManager(PassmanApp passmanApp) {
         this.passmanApp = passmanApp;
+        createNotificationChannel();
     }
 
-    /**
-     * @param passmanApp Application instance the VaultLockManager is initially bound to (only needed on first call)
-     */
     public static synchronized VaultLockManager getInstance(PassmanApp passmanApp) {
         if (instance == null) {
             instance = new VaultLockManager(passmanApp);
         }
         return instance;
+    }
+
+    private void createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            CharSequence name = passmanApp.getString(R.string.security_channel_name);
+            int importance = NotificationManager.IMPORTANCE_DEFAULT;
+            NotificationChannel channel = new NotificationChannel(CHANNEL_ID, name, importance);
+            NotificationManager notificationManager = passmanApp.getSystemService(NotificationManager.class);
+            if (notificationManager != null) {
+                notificationManager.createNotificationChannel(channel);
+            }
+        }
     }
 
     public void updateConfig(int minutes) {
@@ -37,32 +59,86 @@ public class VaultLockManager {
 
     public void resetTimer() {
         handler.removeCallbacks(lockRunnable);
+        handler.removeCallbacks(countdownRunnable);
+        
+        hideOverlayOnCurrentActivity();
+
         if (timeoutMinutes <= 0) {
             return;
         }
 
-        lockRunnable = () -> {
-            Log.d(TAG, "Inactivity timeout reached, locking vault");
-            lockActiveVault();
-        };
+        long totalDelayMillis = (long) timeoutMinutes * 60 * 1000;
+        long countdownStartMillis = totalDelayMillis - 3000;
 
-        handler.postDelayed(lockRunnable, (long) timeoutMinutes * 60 * 1000);
+        if (totalDelayMillis <= 3000) {
+            // If timeout is very short, just lock without countdown for now to avoid complexity
+            lockRunnable = this::lockActiveVault;
+            handler.postDelayed(lockRunnable, totalDelayMillis);
+        } else {
+            countdownRunnable = () -> startCountdown(3);
+            handler.postDelayed(countdownRunnable, countdownStartMillis);
+        }
+    }
+
+    private void startCountdown(int seconds) {
+        if (seconds <= 0) {
+            lockActiveVault();
+            return;
+        }
+
+        showOverlayOnCurrentActivity(seconds);
+
+        countdownRunnable = () -> startCountdown(seconds - 1);
+        handler.postDelayed(countdownRunnable, 1000);
+    }
+
+    private void showOverlayOnCurrentActivity(int seconds) {
+        Activity currentActivity = passmanApp.getCurrentActivity();
+        if (currentActivity instanceof BaseActivity baseActivity) {
+            baseActivity.showCountdownOverlay(seconds);
+        }
+    }
+
+    private void hideOverlayOnCurrentActivity() {
+        Activity currentActivity = passmanApp.getCurrentActivity();
+        if (currentActivity instanceof BaseActivity baseActivity) {
+            baseActivity.hideCountdownOverlay();
+        }
     }
 
     private void lockActiveVault() {
+        hideOverlayOnCurrentActivity();
+        
         SingleTon ton = SingleTon.getTon();
         Vault vault = (Vault) ton.getExtra(SettingValues.ACTIVE_VAULT.toString());
         if (vault != null && vault.is_unlocked()) {
+            Log.d(TAG, "Inactivity timeout reached, locking vault");
             vault.lock();
-            // Update in singleton
             ton.addExtra(SettingValues.ACTIVE_VAULT.toString(), vault);
             ton.addExtra(vault.guid, vault);
             
-            // If the current activity is PasswordListActivity, tell it to update UI
+            postLockedNotification();
+
             Activity currentActivity = passmanApp.getCurrentActivity();
             if (currentActivity instanceof PasswordListActivity passwordListActivity) {
                 passwordListActivity.runOnUiThread(passwordListActivity::lockVault);
             }
+        }
+    }
+
+    private void postLockedNotification() {
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(passmanApp, CHANNEL_ID)
+                .setSmallIcon(R.mipmap.ic_launcher)
+                .setContentTitle(passmanApp.getString(R.string.vault_locked_notification_title))
+                .setContentText(passmanApp.getString(R.string.vault_locked_notification_text))
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setAutoCancel(true);
+
+        NotificationManagerCompat notificationManager = NotificationManagerCompat.from(passmanApp);
+        try {
+            notificationManager.notify(NOTIFICATION_ID, builder.build());
+        } catch (SecurityException e) {
+            Log.e(TAG, "Notification permission missing", e);
         }
     }
 }

--- a/app/src/main/java/es/wolfi/app/passman/VaultLockManager.java
+++ b/app/src/main/java/es/wolfi/app/passman/VaultLockManager.java
@@ -1,0 +1,68 @@
+package es.wolfi.app.passman;
+
+import android.app.Activity;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+
+import es.wolfi.app.passman.activities.PasswordListActivity;
+import es.wolfi.passman.API.Vault;
+
+public class VaultLockManager {
+    private static final String TAG = "VaultLockManager";
+    private static VaultLockManager instance;
+    private final Handler handler = new Handler(Looper.getMainLooper());
+    private Runnable lockRunnable;
+    private int timeoutMinutes = 0;
+    private final PassmanApp passmanApp;
+
+    private VaultLockManager(PassmanApp passmanApp) {
+        this.passmanApp = passmanApp;
+    }
+
+    /**
+     * @param passmanApp Application instance the VaultLockManager is initially bound to (only needed on first call)
+     */
+    public static synchronized VaultLockManager getInstance(PassmanApp passmanApp) {
+        if (instance == null) {
+            instance = new VaultLockManager(passmanApp);
+        }
+        return instance;
+    }
+
+    public void updateConfig(int minutes) {
+        this.timeoutMinutes = minutes;
+        resetTimer();
+    }
+
+    public void resetTimer() {
+        handler.removeCallbacks(lockRunnable);
+        if (timeoutMinutes <= 0) {
+            return;
+        }
+
+        lockRunnable = () -> {
+            Log.d(TAG, "Inactivity timeout reached, locking vault");
+            lockActiveVault();
+        };
+
+        handler.postDelayed(lockRunnable, (long) timeoutMinutes * 60 * 1000);
+    }
+
+    private void lockActiveVault() {
+        SingleTon ton = SingleTon.getTon();
+        Vault vault = (Vault) ton.getExtra(SettingValues.ACTIVE_VAULT.toString());
+        if (vault != null && vault.is_unlocked()) {
+            vault.lock();
+            // Update in singleton
+            ton.addExtra(SettingValues.ACTIVE_VAULT.toString(), vault);
+            ton.addExtra(vault.guid, vault);
+            
+            // If the current activity is PasswordListActivity, tell it to update UI
+            Activity currentActivity = passmanApp.getCurrentActivity();
+            if (currentActivity instanceof PasswordListActivity passwordListActivity) {
+                passwordListActivity.runOnUiThread(passwordListActivity::lockVault);
+            }
+        }
+    }
+}

--- a/app/src/main/java/es/wolfi/app/passman/activities/AutofillInteractionActivity.java
+++ b/app/src/main/java/es/wolfi/app/passman/activities/AutofillInteractionActivity.java
@@ -34,7 +34,6 @@ import android.view.autofill.AutofillId;
 import android.widget.Toast;
 
 import androidx.annotation.RequiresApi;
-import androidx.appcompat.app.AppCompatActivity;
 
 import java.util.ArrayList;
 import java.util.Set;
@@ -51,7 +50,7 @@ import es.wolfi.passman.API.Credential;
 import es.wolfi.passman.API.Vault;
 
 @RequiresApi(api = Build.VERSION_CODES.O)
-public class AutofillInteractionActivity extends AppCompatActivity implements
+public class AutofillInteractionActivity extends BaseActivity implements
         VaultLockScreenFragment.VaultUnlockInteractionListener,
         CredentialItemFragment.OnListFragmentInteractionListener {
     public final static String LOG_TAG = "AutofillInteractionAct.";

--- a/app/src/main/java/es/wolfi/app/passman/activities/BaseActivity.java
+++ b/app/src/main/java/es/wolfi/app/passman/activities/BaseActivity.java
@@ -24,7 +24,7 @@ public abstract class BaseActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        VaultLockManager.getInstance((PassmanApp) getApplication()).resetTimer();
+        VaultLockManager.getInstance((PassmanApp) getApplication()).checkLockOnResume();
     }
 
     public void showCountdownOverlay(int secondsLeft) {

--- a/app/src/main/java/es/wolfi/app/passman/activities/BaseActivity.java
+++ b/app/src/main/java/es/wolfi/app/passman/activities/BaseActivity.java
@@ -1,14 +1,23 @@
 package es.wolfi.app.passman.activities;
 
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
 import androidx.appcompat.app.AppCompatActivity;
 
 import es.wolfi.app.passman.PassmanApp;
+import es.wolfi.app.passman.R;
 import es.wolfi.app.passman.VaultLockManager;
 
 public abstract class BaseActivity extends AppCompatActivity {
+    private View countdownOverlay;
+
     @Override
     public void onUserInteraction() {
         super.onUserInteraction();
+        hideCountdownOverlay();
         VaultLockManager.getInstance((PassmanApp) getApplication()).resetTimer();
     }
 
@@ -16,5 +25,31 @@ public abstract class BaseActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         VaultLockManager.getInstance((PassmanApp) getApplication()).resetTimer();
+    }
+
+    public void showCountdownOverlay(int secondsLeft) {
+        runOnUiThread(() -> {
+            if (countdownOverlay == null) {
+                countdownOverlay = LayoutInflater.from(this).inflate(R.layout.layout_lock_countdown, null);
+                addContentView(
+                        countdownOverlay,
+                        new ViewGroup.LayoutParams(
+                                ViewGroup.LayoutParams.MATCH_PARENT,
+                                ViewGroup.LayoutParams.MATCH_PARENT
+                        )
+                );
+            }
+            countdownOverlay.setVisibility(View.VISIBLE);
+            TextView textView = countdownOverlay.findViewById(R.id.lock_countdown_text);
+            textView.setText(getString(R.string.vault_locking_in, secondsLeft));
+        });
+    }
+
+    public void hideCountdownOverlay() {
+        runOnUiThread(() -> {
+            if (countdownOverlay != null) {
+                countdownOverlay.setVisibility(View.GONE);
+            }
+        });
     }
 }

--- a/app/src/main/java/es/wolfi/app/passman/activities/BaseActivity.java
+++ b/app/src/main/java/es/wolfi/app/passman/activities/BaseActivity.java
@@ -1,0 +1,20 @@
+package es.wolfi.app.passman.activities;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import es.wolfi.app.passman.PassmanApp;
+import es.wolfi.app.passman.VaultLockManager;
+
+public abstract class BaseActivity extends AppCompatActivity {
+    @Override
+    public void onUserInteraction() {
+        super.onUserInteraction();
+        VaultLockManager.getInstance((PassmanApp) getApplication()).resetTimer();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        VaultLockManager.getInstance((PassmanApp) getApplication()).resetTimer();
+    }
+}

--- a/app/src/main/java/es/wolfi/app/passman/activities/BaseActivity.java
+++ b/app/src/main/java/es/wolfi/app/passman/activities/BaseActivity.java
@@ -1,18 +1,30 @@
 package es.wolfi.app.passman.activities;
 
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.widget.TextView;
 
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
 import es.wolfi.app.passman.PassmanApp;
 import es.wolfi.app.passman.R;
+import es.wolfi.app.passman.SettingValues;
 import es.wolfi.app.passman.VaultLockManager;
 
 public abstract class BaseActivity extends AppCompatActivity {
     private View countdownOverlay;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        applyScreenshotProtection();
+    }
 
     @Override
     public void onUserInteraction() {
@@ -24,7 +36,18 @@ public abstract class BaseActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
+        applyScreenshotProtection();
         VaultLockManager.getInstance((PassmanApp) getApplication()).checkLockOnResume();
+    }
+
+    public void applyScreenshotProtection() {
+        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(this);
+        boolean enabled = settings.getBoolean(SettingValues.ENABLE_SCREENSHOT_PROTECTION.toString(), true);
+        if (enabled) {
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
+        } else {
+            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
+        }
     }
 
     public void showCountdownOverlay(int secondsLeft) {

--- a/app/src/main/java/es/wolfi/app/passman/activities/LoginActivity.java
+++ b/app/src/main/java/es/wolfi/app/passman/activities/LoginActivity.java
@@ -35,11 +35,9 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.ScrollView;
 import android.widget.Spinner;
 import android.widget.Toast;
 
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
 import com.koushikdutta.async.future.FutureCallback;
@@ -61,12 +59,11 @@ import es.wolfi.app.passman.R;
 import es.wolfi.app.passman.SettingValues;
 import es.wolfi.app.passman.SingleTon;
 import es.wolfi.app.passman.databinding.ActivityLoginBinding;
-import es.wolfi.app.passman.databinding.ContentLegacyLoginBinding;
 import es.wolfi.passman.API.Core;
 import es.wolfi.utils.KeyStoreUtils;
 import es.wolfi.utils.SSOUtils;
 
-public class LoginActivity extends AppCompatActivity {
+public class LoginActivity extends BaseActivity {
     public final static String LOG_TAG = "LoginActivity";
 
     Spinner input_protocol;

--- a/app/src/main/java/es/wolfi/app/passman/activities/PasswordListActivity.java
+++ b/app/src/main/java/es/wolfi/app/passman/activities/PasswordListActivity.java
@@ -396,6 +396,7 @@ public class PasswordListActivity extends BaseActivity implements
         }
 
         onBackPressed();
+        applyScreenshotProtection();
     }
 
     public void addCredentialToCurrentLocalVaultList(Credential credential) {
@@ -569,6 +570,7 @@ public class PasswordListActivity extends BaseActivity implements
         Toast.makeText(this, R.string.successfully_saved, Toast.LENGTH_SHORT).show();
 
         updateShortcuts();
+        applyScreenshotProtection();
 
         if (doRebirth) {
             triggerRebirth(this);

--- a/app/src/main/java/es/wolfi/app/passman/activities/PasswordListActivity.java
+++ b/app/src/main/java/es/wolfi/app/passman/activities/PasswordListActivity.java
@@ -68,10 +68,12 @@ import java.util.HashMap;
 import java.util.Objects;
 
 import es.wolfi.app.passman.OfflineStorage;
+import es.wolfi.app.passman.PassmanApp;
 import es.wolfi.app.passman.R;
 import es.wolfi.app.passman.SettingValues;
 import es.wolfi.app.passman.SettingsCache;
 import es.wolfi.app.passman.SingleTon;
+import es.wolfi.app.passman.VaultLockManager;
 import es.wolfi.app.passman.fragments.CredentialAddFragment;
 import es.wolfi.app.passman.fragments.CredentialDisplayFragment;
 import es.wolfi.app.passman.fragments.CredentialEditFragment;
@@ -87,7 +89,7 @@ import es.wolfi.utils.FileUtils;
 import es.wolfi.utils.KeyStoreUtils;
 import es.wolfi.utils.ProgressUtils;
 
-public class PasswordListActivity extends AppCompatActivity implements
+public class PasswordListActivity extends BaseActivity implements
         VaultFragment.OnListFragmentInteractionListener,
         CredentialItemFragment.OnListFragmentInteractionListener,
         VaultLockScreenFragment.VaultUnlockInteractionListener,
@@ -145,6 +147,7 @@ public class PasswordListActivity extends AppCompatActivity implements
         KeyStoreUtils.initialize(settings);
         new OfflineStorage(getBaseContext());
         initialAuthentication(false);
+        VaultLockManager.getInstance((PassmanApp) getApplication()).updateConfig(settings.getInt(SettingValues.VAULT_AUTO_LOCK_DELAY.toString(), 0));
     }
 
     private void initialAuthentication(boolean skipKeyguard) {
@@ -368,7 +371,7 @@ public class PasswordListActivity extends AppCompatActivity implements
                 .commitAllowingStateLoss();
     }
 
-    void lockVault() {
+    public void lockVault() {
         final Vault vault = (Vault) ton.getExtra(SettingValues.ACTIVE_VAULT.toString());
         vault.lock();
         ton.removeExtra(vault.guid);

--- a/app/src/main/java/es/wolfi/app/passman/activities/PasswordListActivity.java
+++ b/app/src/main/java/es/wolfi/app/passman/activities/PasswordListActivity.java
@@ -381,6 +381,7 @@ public class PasswordListActivity extends BaseActivity implements
 
     public void lockVault() {
         final Vault vault = (Vault) ton.getExtra(SettingValues.ACTIVE_VAULT.toString());
+        if (vault == null) return;
         vault.lock();
         ton.removeExtra(vault.guid);
         ton.addExtra(vault.guid, vault);

--- a/app/src/main/java/es/wolfi/app/passman/activities/PasswordListActivity.java
+++ b/app/src/main/java/es/wolfi/app/passman/activities/PasswordListActivity.java
@@ -175,6 +175,14 @@ public class PasswordListActivity extends BaseActivity implements
 
                     if (loggedIn) {
                         showVaults();
+                        if (
+                                Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                                && settings.getInt(SettingValues.VAULT_AUTO_LOCK_DELAY.toString(), 0) > 0
+                        ) {
+                            if (checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+                                requestPermissions(new String[]{android.Manifest.permission.POST_NOTIFICATIONS}, 101);
+                            }
+                        }
                     } else {
                         // If not logged in, show login form!
                         Intent intent = new Intent(PasswordListActivity.this, LoginActivity.class);
@@ -573,6 +581,14 @@ public class PasswordListActivity extends BaseActivity implements
 
                     if (loggedIn) {
                         showVaults();
+                        if (
+                                Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                                && settings.getInt(SettingValues.VAULT_AUTO_LOCK_DELAY.toString(), 0) > 0
+                        ) {
+                            if (checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+                                requestPermissions(new String[]{android.Manifest.permission.POST_NOTIFICATIONS}, 101);
+                            }
+                        }
                     } else {
                         // If not logged in, show login form!
                         Intent intent = new Intent(PasswordListActivity.this, LoginActivity.class);

--- a/app/src/main/java/es/wolfi/app/passman/activities/ScanQRCodeActivity.java
+++ b/app/src/main/java/es/wolfi/app/passman/activities/ScanQRCodeActivity.java
@@ -15,7 +15,6 @@ import android.view.animation.AnimationUtils;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.camera.core.AspectRatio;
 import androidx.camera.core.CameraSelector;
 import androidx.camera.core.ImageAnalysis;
@@ -37,7 +36,7 @@ import java.util.concurrent.Executors;
 import es.wolfi.app.passman.R;
 import es.wolfi.utils.QrCodeAnalyzer;
 
-public class ScanQRCodeActivity extends AppCompatActivity {
+public class ScanQRCodeActivity extends BaseActivity {
 
     public final static String LOG_TAG = ScanQRCodeActivity.class.getSimpleName();
 

--- a/app/src/main/java/es/wolfi/app/passman/activities/ShortcutActivity.java
+++ b/app/src/main/java/es/wolfi/app/passman/activities/ShortcutActivity.java
@@ -26,12 +26,10 @@ import android.content.Context;
 import android.os.Bundle;
 import android.widget.Toast;
 
-import androidx.appcompat.app.AppCompatActivity;
-
 import es.wolfi.app.passman.R;
 import es.wolfi.utils.PasswordGenerator;
 
-public class ShortcutActivity extends AppCompatActivity {
+public class ShortcutActivity extends BaseActivity {
     public final static String LOG_TAG = "ShortcutActivity";
     public final static String GENERATE_PASSWORD_ID = "es.wolfi.app.passman.generate_password";
     public final static String GENERATE_PASSWORD_INTENT_ACTION = "custom.actions.intent.GENERATE_PASSWORD";

--- a/app/src/main/java/es/wolfi/app/passman/fragments/SettingsFragment.java
+++ b/app/src/main/java/es/wolfi/app/passman/fragments/SettingsFragment.java
@@ -89,6 +89,7 @@ public class SettingsFragment extends Fragment {
     EditText settings_nextcloud_password;
 
     MaterialCheckBox settings_app_start_password_switch;
+    MaterialCheckBox settings_enable_screenshot_protection_switch;
 
     MaterialCheckBox settings_password_generator_shortcut_switch;
     MaterialCheckBox settings_password_generator_use_uppercase_switch;
@@ -155,6 +156,7 @@ public class SettingsFragment extends Fragment {
         settings_nextcloud_password = view.findViewById(R.id.settings_nextcloud_password);
 
         settings_app_start_password_switch = view.findViewById(R.id.settings_app_start_password_switch);
+        settings_enable_screenshot_protection_switch = view.findViewById(R.id.settings_enable_screenshot_protection_switch);
 
         settings_password_generator_shortcut_switch = view.findViewById(R.id.settings_password_generator_shortcut_switch);
         settings_password_generator_use_uppercase_switch = view.findViewById(R.id.settings_password_generator_use_uppercase_switch);
@@ -223,6 +225,7 @@ public class SettingsFragment extends Fragment {
         settings_nextcloud_password.setText(KeyStoreUtils.getString(SettingValues.PASSWORD.toString(), null));
 
         settings_app_start_password_switch.setChecked(settings.getBoolean(SettingValues.ENABLE_APP_START_DEVICE_PASSWORD.toString(), false));
+        settings_enable_screenshot_protection_switch.setChecked(settings.getBoolean(SettingValues.ENABLE_SCREENSHOT_PROTECTION.toString(), true));
 
         passwordGenerator = new PasswordGenerator(context);
 
@@ -350,6 +353,7 @@ public class SettingsFragment extends Fragment {
                 SingleTon ton = SingleTon.getTon();
 
                 settings.edit().putBoolean(SettingValues.ENABLE_APP_START_DEVICE_PASSWORD.toString(), settings_app_start_password_switch.isChecked()).commit();
+                settings.edit().putBoolean(SettingValues.ENABLE_SCREENSHOT_PROTECTION.toString(), settings_enable_screenshot_protection_switch.isChecked()).commit();
 
                 settings.edit().putBoolean(SettingValues.ENABLE_PASSWORD_GENERATOR_SHORTCUT.toString(), settings_password_generator_shortcut_switch.isChecked()).commit();
 

--- a/app/src/main/java/es/wolfi/app/passman/fragments/SettingsFragment.java
+++ b/app/src/main/java/es/wolfi/app/passman/fragments/SettingsFragment.java
@@ -65,10 +65,12 @@ import java.util.Objects;
 import java.util.Set;
 
 import es.wolfi.app.passman.OfflineStorage;
+import es.wolfi.app.passman.PassmanApp;
 import es.wolfi.app.passman.R;
 import es.wolfi.app.passman.SettingValues;
 import es.wolfi.app.passman.SettingsCache;
 import es.wolfi.app.passman.SingleTon;
+import es.wolfi.app.passman.VaultLockManager;
 import es.wolfi.app.passman.activities.PasswordListActivity;
 import es.wolfi.passman.API.Vault;
 import es.wolfi.utils.KeyStoreUtils;
@@ -111,6 +113,7 @@ public class SettingsFragment extends Fragment {
 
     EditText request_connect_timeout_value;
     EditText request_response_timeout_value;
+    EditText vault_auto_lock_delay_value;
     Button clear_offline_cache_button;
 
     SharedPreferences settings;
@@ -177,6 +180,7 @@ public class SettingsFragment extends Fragment {
 
         request_connect_timeout_value = view.findViewById(R.id.request_connect_timeout_value);
         request_response_timeout_value = view.findViewById(R.id.request_response_timeout_value);
+        vault_auto_lock_delay_value = view.findViewById(R.id.vault_auto_lock_delay_value);
         clear_offline_cache_button = view.findViewById(R.id.clear_offline_cache_button);
         clear_offline_cache_button.setOnClickListener(this.getClearOfflineCacheButtonListener());
 
@@ -291,6 +295,7 @@ public class SettingsFragment extends Fragment {
 
         request_connect_timeout_value.setText(String.valueOf(settings.getInt(SettingValues.REQUEST_CONNECT_TIMEOUT.toString(), 15)));
         request_response_timeout_value.setText(String.valueOf(settings.getInt(SettingValues.REQUEST_RESPONSE_TIMEOUT.toString(), 120)));
+        vault_auto_lock_delay_value.setText(String.valueOf(settings.getInt(SettingValues.VAULT_AUTO_LOCK_DELAY.toString(), 0)));
         clear_offline_cache_button.setText(String.format("%s (%s)", getString(R.string.clear_offline_cache), OfflineStorage.getInstance().getSize()));
     }
 
@@ -369,6 +374,10 @@ public class SettingsFragment extends Fragment {
 
                 settings.edit().putInt(SettingValues.REQUEST_CONNECT_TIMEOUT.toString(), Integer.parseInt(request_connect_timeout_value.getText().toString())).commit();
                 settings.edit().putInt(SettingValues.REQUEST_RESPONSE_TIMEOUT.toString(), Integer.parseInt(request_response_timeout_value.getText().toString())).commit();
+
+                int autoLockDelay = Integer.parseInt(vault_auto_lock_delay_value.getText().toString());
+                settings.edit().putInt(SettingValues.VAULT_AUTO_LOCK_DELAY.toString(), autoLockDelay).commit();
+                VaultLockManager.getInstance((PassmanApp) getActivity().getApplication()).updateConfig(autoLockDelay);
 
                 if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
                     settings.edit().putBoolean(SettingValues.ENABLE_AUTOFILL_MANUAL_SEARCH_FALLBACK.toString(), enable_autofill_manual_search_fallback.isChecked()).commit();

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -68,7 +68,7 @@
                 style="@style/Label"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/app_start_password" />
+                android:text="@string/app_security" />
 
             <com.google.android.material.checkbox.MaterialCheckBox
                 android:id="@+id/settings_app_start_password_switch"
@@ -77,6 +77,14 @@
                 android:layout_marginTop="10dp"
                 android:checked="false"
                 android:text="@string/app_start_password_android_auth_description" />
+
+            <com.google.android.material.checkbox.MaterialCheckBox
+                android:id="@+id/settings_enable_screenshot_protection_switch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:checked="false"
+                android:text="@string/enable_screenshot_protection" />
 
             <TextView
                 style="@style/Label"

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -245,6 +245,21 @@
                 style="@style/Label"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:text="@string/vault_auto_lock_delay" />
+
+            <EditText
+                android:id="@+id/vault_auto_lock_delay_value"
+                style="@style/FormText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:digits="0123456789"
+                android:inputType="number"
+                tools:ignore="LabelFor" />
+
+            <TextView
+                style="@style/Label"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:text="@string/credential_list_sort_settings" />
 
             <com.google.android.material.checkbox.MaterialCheckBox

--- a/app/src/main/res/layout/layout_lock_countdown.xml
+++ b/app/src/main/res/layout/layout_lock_countdown.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/lock_countdown_overlay"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#99000000"
+    android:clickable="true"
+    android:focusable="true">
+
+    <TextView
+        android:id="@+id/lock_countdown_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:textColor="@android:color/white"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        android:text="@string/vault_locking_in" />
+
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,10 @@
     <string name="credential_icon">Credential icon</string>
     <string name="clear_clipboard_delay">Clear clipboard (after seconds)</string>
     <string name="vault_auto_lock_delay">Vault auto-lock (after minutes)</string>
+    <string name="vault_locking_in">Vault will be locked in %1$d seconds</string>
+    <string name="vault_locked_notification_title">Vault Locked</string>
+    <string name="vault_locked_notification_text">The active vault has been automatically locked due to inactivity.</string>
+    <string name="security_channel_name">Vault Security</string>
     <string name="generate_password">Generate password</string>
     <string name="generate_password_to_clipboard">Generate a random password and copy to clipboard</string>
     <string name="enable_password_generator_shortcut_description">Enable password generator app shortcut</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,7 @@
     <string name="enable_credential_list_icons">Enable credential list icons</string>
     <string name="credential_icon">Credential icon</string>
     <string name="clear_clipboard_delay">Clear clipboard (after seconds)</string>
+    <string name="vault_auto_lock_delay">Vault auto-lock (after minutes)</string>
     <string name="generate_password">Generate password</string>
     <string name="generate_password_to_clipboard">Generate a random password and copy to clipboard</string>
     <string name="enable_password_generator_shortcut_description">Enable password generator app shortcut</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="add_custom_field">Add custom field</string>
     <string name="unlock_passman">Unlock Passman</string>
     <string name="unlock_passman_message_device_auth">Please authenticate to access Passman</string>
+    <string name="app_security">App security</string>
     <string name="app_start_password">App start password</string>
     <string name="app_start_password_android_auth_description">Enable Android user authentication on app start</string>
     <string name="wait_while_encrypting">Wait while encrypting …</string>
@@ -68,6 +69,7 @@
     <string name="credential_icon">Credential icon</string>
     <string name="clear_clipboard_delay">Clear clipboard (after seconds)</string>
     <string name="vault_auto_lock_delay">Vault auto-lock (after minutes)</string>
+    <string name="enable_screenshot_protection">Hide app content in recents, screenshots and on non-secure displays</string>
     <string name="vault_locking_in">Vault will be locked in %1$d seconds</string>
     <string name="vault_locked_notification_title">Vault Locked</string>
     <string name="vault_locked_notification_text">The active vault has been automatically locked due to inactivity.</string>


### PR DESCRIPTION
- add option to close the vault after a period of not being used; closes #159 
  - shows an in-app countdown overlay 3 seconds before locking the vault to give users time to intercept
- implement secure content (aka screenshot protection) option which is enabled by default
